### PR TITLE
Use Hackage/Cabal friendly stack settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -63,3 +63,5 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+pvp-bounds: both


### PR DESCRIPTION
This helps provide more accurate version bounds in the cabal metadata which are essential
to Hackage/Cabal which relies on accurate version bounds in order to operate well, reduce the
risk of build-plan bitrotting over time, and therefore provide a good experience to Hackage users.

See also https://matrix.hackage.haskell.org/package/tensors